### PR TITLE
Add long_description_content_type for PyPI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ keywords = squeezebox, slimserver, lms, Lyrion, hy
 license = GPL-3
 license_file = LICENSE
 long_description = file: README.md
+long_description_content_type = text/markdown
 
 
 [options]


### PR DESCRIPTION
## Summary

Fixes PyPI upload error by specifying `long_description_content_type = text/markdown` in setup.cfg.

PyPI expects reStructuredText by default, but our README is Markdown.

## Error

```
400 The description failed to render in the default format of reStructuredText.
```

## Fix

Add `long_description_content_type = text/markdown` to metadata section.