### PR TITLE
Fix config: support [default] section in config.toml

### DIFF
--- a/ncsb/cli.py
+++ b/ncsb/cli.py
@@ -89,7 +89,17 @@ CONFIG_FILE = Path.home() / '.config' / 'ncsb' / 'config.toml'
 
 
 def read_config():
-    """Read config file and return defaults dict for click."""
+    """Read config file and return defaults dict for click.
+    
+    Supports both flat config and [default] section:
+        host = "sol"
+        player = "juno"
+    
+    or:
+        [default]
+        host = "sol"
+        player = "juno"
+    """
     if not CONFIG_FILE.exists():
         return {}
     try:
@@ -99,7 +109,9 @@ def read_config():
     
     try:
         with open(CONFIG_FILE, 'rb') as f:
-            return tomllib.load(f)
+            cfg = tomllib.load(f)
+        # Support [default] section or flat config
+        return cfg.get('default', cfg)
     except Exception:
         return {}
 


### PR DESCRIPTION
## Problem

`read_config()` returned the raw TOML dict, which includes the `[default]` key when users structure their config with a section header. Click's `default_map` expects a flat dict, so configs with `[default]` were ignored.

## Solution

Extract the `[default]` section if present, falling back to flat config:

```python
cfg = tomllib.load(f)
return cfg.get('default', cfg)
```

## Testing

Both formats now work:

```toml
# Flat config
host = "sol"
player = "juno"
```

```toml
# Section config
[default]
host = "sol"
player = "juno"
```