### PR TITLE
Add ncsb-notifyd desktop notification daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,23 @@ In-terminal coverart requires libsixel to be installed on your system (presumabl
 - because the font size and resolution is not known to curses, the album art size cannot be scaled to a terminal-appropriate size
 
 
+## Desktop Notifications
+
+To get desktop notifications when the track changes, use the notify daemon:
+
+```bash
+# Run in background (requires ncsb, jq, notify-send, curl)
+ncsb-notifyd juno &
+
+# Or with environment variables
+NCSB_PLAYER=eos POLL_INTERVAL=3 ncsb-notifyd
+```
+
+The daemon polls LMS every 2 seconds (configurable via `POLL_INTERVAL`) and sends `notify-send` with album art when the track or playback state changes.
+
+A sample script is available in `contrib/ncsb-notifyd.sh`.
+
+
 ## Credits
 
 Copyright A S Sharma (2021), released under the GPL v3.0 (see LICENSE and AUTHORS).

--- a/README.md
+++ b/README.md
@@ -127,27 +127,27 @@ Show current config: `ncsb config`
 
 ```bash
 # List players
-ncsb -H sol players
+ncsb players
 
 # Show current track
-ncsb -H sol -P juno info
+ncsb -P juno info
 
 # Search and play
-ncsb -H sol -P juno search kind of blue --kind albums
-ncsb -H sol -P juno load album 6468
+ncsb -P juno search kind of blue --kind albums
+ncsb -P juno load album 6468
 
 # Volume control
-ncsb -H sol -P juno volume 75
-ncsb -H sol -P juno vol+ 5
+ncsb -P juno volume 75
+ncsb -P juno vol+ 5
 
 # Play radio stream
-ncsb -H sol -P juno radio https://stream.example.com/mp3 --title "Jazz FM"
+ncsb -P juno radio https://stream.example.com/mp3 --title "Jazz FM"
 
 # Set sleep timer
-ncsb -H sol -P juno sleep 30
+ncsb -P juno sleep 30
 
 # JSON output for scripting
-ncsb -H sol -P juno playing --json
+ncsb -P juno playing --json
 ```
 
 
@@ -184,7 +184,7 @@ ncsb-notifyd juno &
 NCSB_PLAYER=eos POLL_INTERVAL=3 ncsb-notifyd
 ```
 
-The daemon polls LMS every 2 seconds (configurable via `POLL_INTERVAL`) and sends `notify-send` with album art when the track or playback state changes.
+The daemon uses ncsb's config/env handling for host and port. It polls every 2 seconds (configurable via `POLL_INTERVAL`) and sends `notify-send` with album art when the track or playback state changes.
 
 A sample script is available in `contrib/ncsb-notifyd.sh`.
 

--- a/contrib/ncsb-notifyd.sh
+++ b/contrib/ncsb-notifyd.sh
@@ -8,17 +8,15 @@
 #   ncsb-notifyd [PLAYER]
 #   NCSB_PLAYER=eos ncsb-notifyd
 #
+# Config: Uses ncsb's config/env handling (see: ncsb config)
+#
 # Environment:
-#   NCSB_PLAYER  - Player name (default: eos)
-#   LMS_HOST     - LMS server host (default: sol.wg.letterbox.pw)
-#   LMS_PORT     - LMS server port (default: 9000)
-#   POLL_INTERVAL - Polling interval in seconds (default: 2)
+#   NCSB_PLAYER    - Player name (default: from config)
+#   POLL_INTERVAL  - Polling interval in seconds (default: 2)
 
 set -euo pipefail
 
-PLAYER="${1:-${NCSB_PLAYER:-eos}}"
-HOST="${LMS_HOST:-sol.wg.letterbox.pw}"
-PORT="${LMS_PORT:-9000}"
+PLAYER="${1:-${NCSB_PLAYER:-}}"
 POLL_INTERVAL="${POLL_INTERVAL:-2}"
 
 # State tracking
@@ -33,8 +31,14 @@ fetch_cover() {
     local coverid="$1"
     local cover_file="/tmp/ncsb-cover-$coverid.jpg"
     
+    # Get host from ncsb config
+    local host
+    host=$(ncsb config 2>/dev/null | grep "^  host:" | cut -d: -f2- | xargs) || host="localhost"
+    local port
+    port=$(ncsb config 2>/dev/null | grep "^  port:" | cut -d: -f2- | xargs) || port="9000"
+    
     if [ -n "$coverid" ] && [ ! -f "$cover_file" ]; then
-        curl -s "http://$HOST:$PORT/music/$coverid/cover.jpg" -o "$cover_file" 2>/dev/null || true
+        curl -s "http://$host:$port/music/$coverid/cover.jpg" -o "$cover_file" 2>/dev/null || true
     fi
     
     echo "$cover_file"
@@ -68,8 +72,11 @@ send_notification() {
 }
 
 poll() {
+    local cmd_args=()
+    [ -n "$PLAYER" ] && cmd_args=(-P "$PLAYER")
+    
     local status
-    status=$(ncsb -P "$PLAYER" status 2>/dev/null) || return 0
+    status=$(ncsb "${cmd_args[@]}" status 2>/dev/null) || return 0
     
     local track_id mode title album artist coverid
     track_id=$(echo "$status" | jq -r '.playlist_loop[0].id // empty')
@@ -92,7 +99,7 @@ poll() {
 }
 
 # Main loop
-log "Starting ncsb-notifyd for player: $PLAYER (poll: ${POLL_INTERVAL}s)"
+log "Starting ncsb-notifyd${PLAYER:+ for player: $PLAYER} (poll: ${POLL_INTERVAL}s)"
 
 while true; do
     poll

--- a/contrib/ncsb-notifyd.sh
+++ b/contrib/ncsb-notifyd.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# ncsb-notifyd — Daemon to notify on track/state changes
+#
+# Polls LMS and sends notify-send when track changes or playback state changes.
+# Requires: ncsb, jq, notify-send, curl
+#
+# Usage:
+#   ncsb-notifyd [PLAYER]
+#   NCSB_PLAYER=eos ncsb-notifyd
+#
+# Environment:
+#   NCSB_PLAYER  - Player name (default: eos)
+#   LMS_HOST     - LMS server host (default: sol.wg.letterbox.pw)
+#   LMS_PORT     - LMS server port (default: 9000)
+#   POLL_INTERVAL - Polling interval in seconds (default: 2)
+
+set -euo pipefail
+
+PLAYER="${1:-${NCSB_PLAYER:-eos}}"
+HOST="${LMS_HOST:-sol.wg.letterbox.pw}"
+PORT="${LMS_PORT:-9000}"
+POLL_INTERVAL="${POLL_INTERVAL:-2}"
+
+# State tracking
+PREV_TRACK_ID=""
+PREV_MODE=""
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >&2
+}
+
+fetch_cover() {
+    local coverid="$1"
+    local cover_file="/tmp/ncsb-cover-$coverid.jpg"
+    
+    if [ -n "$coverid" ] && [ ! -f "$cover_file" ]; then
+        curl -s "http://$HOST:$PORT/music/$coverid/cover.jpg" -o "$cover_file" 2>/dev/null || true
+    fi
+    
+    echo "$cover_file"
+}
+
+send_notification() {
+    local title="$1"
+    local album="$2"
+    local artist="$3"
+    local cover_file="$4"
+    local mode="$5"
+    
+    local body="$album"
+    [ -n "$artist" ] && body="$album"$'\n'"$artist"
+    
+    # Mode indicator
+    local icon=""
+    case "$mode" in
+        play) icon="▶" ;;
+        pause) icon="⏸" ;;
+        stop) icon="⏹" ;;
+    esac
+    [ -n "$icon" ] && title="$icon $title"
+    
+    local notify_opts=()
+    if [ -f "$cover_file" ]; then
+        notify_opts=(-i "$cover_file")
+    fi
+    
+    notify-send "${notify_opts[@]}" "$title" "$body"
+}
+
+poll() {
+    local status
+    status=$(ncsb -P "$PLAYER" status 2>/dev/null) || return 0
+    
+    local track_id mode title album artist coverid
+    track_id=$(echo "$status" | jq -r '.playlist_loop[0].id // empty')
+    mode=$(echo "$status" | jq -r '.mode // "stop"')
+    title=$(echo "$status" | jq -r '.playlist_loop[0].title // "Unknown"')
+    album=$(echo "$status" | jq -r '.playlist_loop[0].album // ""')
+    artist=$(echo "$status" | jq -r '.playlist_loop[0].artist // ""')
+    coverid=$(echo "$status" | jq -r '.playlist_loop[0].coverid // empty')
+    
+    # Check for changes
+    if [ "$track_id" != "$PREV_TRACK_ID" ] || [ "$mode" != "$PREV_MODE" ]; then
+        local cover_file=""
+        [ -n "$coverid" ] && cover_file=$(fetch_cover "$coverid")
+        
+        send_notification "$title" "$album" "$artist" "$cover_file" "$mode"
+        
+        PREV_TRACK_ID="$track_id"
+        PREV_MODE="$mode"
+    fi
+}
+
+# Main loop
+log "Starting ncsb-notifyd for player: $PLAYER (poll: ${POLL_INTERVAL}s)"
+
+while true; do
+    poll
+    sleep "$POLL_INTERVAL"
+done


### PR DESCRIPTION
## What

Adds a polling daemon that sends `notify-send` with album art when the track or playback state changes.

## Usage

```bash
# Run in background
ncsb-notifyd juno &

# With options
NCSB_PLAYER=eos POLL_INTERVAL=3 ncsb-notifyd
```

## Config

Uses ncsb's config/env handling for host and port — no hardcoded values.

## Requirements

- `ncsb` CLI
- `jq`
- `notify-send` (libnotify)
- `curl`

## Files

- `contrib/ncsb-notifyd.sh` — the daemon script
- Updated `README.md` with documentation